### PR TITLE
feat: optimize hotspot caching and notification

### DIFF
--- a/dao/mysql/notification.go
+++ b/dao/mysql/notification.go
@@ -1,0 +1,97 @@
+package mysql
+
+import (
+	"database/sql"
+	"time"
+
+	"bluebell/models"
+)
+
+// InsertNotification 将通知事件写入数据库。
+func InsertNotification(event *models.NotificationEvent) error {
+	if event == nil {
+		return nil
+	}
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now()
+	}
+	sqlStr := `INSERT INTO user_notification (id, receiver_id, actor_id, post_id, comment_id, type, message, create_time)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err := db.Exec(sqlStr, event.ID, event.ReceiverID, event.ActorID, event.PostID, event.CommentID, event.Type, event.Message, event.CreatedAt)
+	return err
+}
+
+// ListNotificationsAfter 获取指定 ID 之后的通知，避免深度分页。
+func ListNotificationsAfter(userID, lastID int64, limit int) ([]*models.NotificationEvent, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	sqlStr := `SELECT id, receiver_id, actor_id, post_id, comment_id, type, message, create_time
+FROM user_notification
+WHERE receiver_id = ? AND id > ?
+ORDER BY id ASC
+LIMIT ?`
+	rows, err := db.Query(sqlStr, userID, lastID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	list := make([]*models.NotificationEvent, 0, limit)
+	for rows.Next() {
+		item := new(models.NotificationEvent)
+		if err := rows.Scan(&item.ID, &item.ReceiverID, &item.ActorID, &item.PostID, &item.CommentID, &item.Type, &item.Message, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		list = append(list, item)
+	}
+	return list, rows.Err()
+}
+
+// ListLatestNotifications 首次拉取时获取固定数量的数据。
+func ListLatestNotifications(userID int64, limit int) ([]*models.NotificationEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	sqlStr := `SELECT id, receiver_id, actor_id, post_id, comment_id, type, message, create_time
+FROM user_notification
+WHERE receiver_id = ?
+ORDER BY id DESC
+LIMIT ?`
+	rows, err := db.Query(sqlStr, userID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	list := make([]*models.NotificationEvent, 0, limit)
+	for rows.Next() {
+		item := new(models.NotificationEvent)
+		if err := rows.Scan(&item.ID, &item.ReceiverID, &item.ActorID, &item.PostID, &item.CommentID, &item.Type, &item.Message, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		list = append(list, item)
+	}
+	// 逆序返回，保持时间顺序
+	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+		list[i], list[j] = list[j], list[i]
+	}
+	return list, rows.Err()
+}
+
+// GetLastNotificationID 查询某个用户最新的通知 ID。
+func GetLastNotificationID(userID int64) (int64, error) {
+	sqlStr := `SELECT id FROM user_notification WHERE receiver_id = ? ORDER BY id DESC LIMIT 1`
+	var id sql.NullInt64
+	err := db.QueryRow(sqlStr, userID).Scan(&id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if id.Valid {
+		return id.Int64, nil
+	}
+	return 0, nil
+}

--- a/dao/mysql/post.go
+++ b/dao/mysql/post.go
@@ -79,3 +79,22 @@ func DeletePostVote(userID int64, postID string) error {
 	_, err := db.Exec(sqlStr, userID, postID)
 	return err
 }
+
+// UpsertPostLikeStat 将热点帖子累计的点赞量增量写入数据库。
+//
+// 表结构示例：
+// CREATE TABLE IF NOT EXISTS post_like_stat (
+//
+//	post_id BIGINT PRIMARY KEY,
+//	like_count BIGINT NOT NULL DEFAULT 0
+//
+// );
+func UpsertPostLikeStat(postID int64, delta int64) error {
+	if delta == 0 {
+		return nil
+	}
+	sqlStr := `INSERT INTO post_like_stat (post_id, like_count) VALUES (?, ?)
+ON DUPLICATE KEY UPDATE like_count = GREATEST(0, like_count + VALUES(like_count))`
+	_, err := db.Exec(sqlStr, postID, delta)
+	return err
+}

--- a/dao/redis/redis.go
+++ b/dao/redis/redis.go
@@ -36,3 +36,13 @@ func Init(cfg *setting.RedisConfig) (err error) {
 func Close() {
 	_ = client.Close()
 }
+
+// GetClient 返回初始化好的 Redis 客户端实例。
+//
+// 在热点识别、排行榜等高级功能中，我们需要直接使用底层的 Redis API
+// 来完成批量管道、布隆过滤器等操作。为了避免在项目的其他位置重复
+// 初始化客户端，这里提供一个安全的只读访问接口。调用方在使用时需
+// 要确保在 dao/redis.Init 成功之后再调用该方法。
+func GetClient() *redis.Client {
+	return client
+}

--- a/dao/redis/vote.go
+++ b/dao/redis/vote.go
@@ -102,14 +102,14 @@ func CreatePost(postID, communityID int64) error {
 	return err
 }
 
-func VoteForPost(userID, postID string, value float64) error {
+func VoteForPost(userID, postID string, value float64) (float64, error) {
 	// 1. 判断投票限制
 	// 去redis取帖子发布时间
 	postTime := client.ZScore(context.Background(), getRedisKey(KeyPostTimeZSet), postID).Val()
-	//这一行是取帖子发布时间,原理是zscore,zscore是取有序集合中指定成员的分数
-	//client是redis的客户端,提供了Redis操作接口
+	// 这一行是取帖子发布时间,原理是zscore,zscore是取有序集合中指定成员的分数
+	// client是redis的客户端,提供了Redis操作接口
 	if float64(time.Now().Unix())-postTime > oneWeekInSeconds {
-		return ErrVoteTimeExpire
+		return 0, ErrVoteTimeExpire
 	}
 	// 2和3需要放到一个pipeline事务中操作
 
@@ -151,7 +151,7 @@ func VoteForPost(userID, postID string, value float64) error {
 
 	// 更新：如果这一次投票的值和之前保存的值一致，就提示不允许重复投票
 	if value == ov {
-		return ErrVoteRepeated
+		return ov, ErrVoteRepeated
 	}
 	var op float64
 	if value > ov {
@@ -199,6 +199,8 @@ func VoteForPost(userID, postID string, value float64) error {
 			Member: userID, // 用户ID作为成员标识
 		})
 	}
+	// 统一控制点赞关系的生命周期，降低冷数据占用
+	pipeline.Expire(context.Background(), getRedisKey(KeyPostVotedZSetPF+postID), 15*24*time.Hour)
 	_, err := pipeline.Exec(context.Background())
-	return err
+	return ov, err
 }

--- a/logic/notify.go
+++ b/logic/notify.go
@@ -1,0 +1,170 @@
+package logic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"bluebell/dao/mysql"
+	redispkg "bluebell/dao/redis"
+	"bluebell/models"
+	"bluebell/pkg/snowflake"
+
+	redis "github.com/go-redis/redis/v8"
+	"go.uber.org/zap"
+)
+
+// NotificationService 封装通知写入 MQ、落库以及前端节流拉取的流程。
+type NotificationService struct {
+	client       *redis.Client
+	queueKey     string
+	pullKey      string
+	intervalKey  string
+	backoffSteps []time.Duration
+}
+
+var notifyService = NewNotificationService()
+
+// NewNotificationService 创建通知服务实例。
+func NewNotificationService() *NotificationService {
+	client := redispkg.GetClient()
+	return &NotificationService{
+		client:       client,
+		queueKey:     "bluebell:notify:queue",
+		pullKey:      "bluebell:notify:last:%d",
+		intervalKey:  "bluebell:notify:interval:%d",
+		backoffSteps: []time.Duration{5 * time.Second, 10 * time.Second, 20 * time.Second, 60 * time.Second, 5 * time.Minute},
+	}
+}
+
+// PublishLikeNotification 点赞或评论动作写入 MQ。
+func PublishLikeNotification(ctx context.Context, event *models.NotificationEvent) error {
+	if event == nil {
+		return nil
+	}
+	if event.ID == 0 {
+		event.ID = snowflake.GenID()
+	}
+	payload, err := jsonMarshal(event)
+	if err != nil {
+		return err
+	}
+	return notifyService.client.LPush(ctx, notifyService.queueKey, payload).Err()
+}
+
+// StartNotificationConsumer 异步消费 MQ 并写入数据库。
+func StartNotificationConsumer(ctx context.Context) {
+	go notifyService.consume(ctx)
+}
+
+func (s *NotificationService) consume(ctx context.Context) {
+	for {
+		result, err := s.client.BRPop(ctx, time.Minute, s.queueKey).Result()
+		if err != nil {
+			if err == redis.Nil {
+				continue
+			}
+			zap.L().Error("notification BRPop failed", zap.Error(err))
+			continue
+		}
+		if len(result) != 2 {
+			continue
+		}
+		event, err := jsonUnmarshalNotification([]byte(result[1]))
+		if err != nil {
+			zap.L().Error("notification unmarshal failed", zap.Error(err))
+			continue
+		}
+		if err := mysql.InsertNotification(event); err != nil {
+			zap.L().Error("InsertNotification failed", zap.Error(err))
+			continue
+		}
+	}
+}
+
+// FetchNotifications 结合前端的 lastID 控制拉取范围与频率。
+func FetchNotifications(ctx context.Context, userID int64, param *models.NotificationPullParam) ([]*models.NotificationEvent, time.Duration, error) {
+	if param == nil {
+		param = &models.NotificationPullParam{}
+	}
+	limit := param.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	lastID := param.LastID
+	if lastID == 0 {
+		cached := notifyService.getLastPulledID(ctx, userID)
+		if cached != 0 {
+			lastID = cached
+		}
+	}
+
+	var (
+		events []*models.NotificationEvent
+		err    error
+	)
+
+	if lastID == 0 {
+		events, err = mysql.ListLatestNotifications(userID, limit)
+	} else {
+		events, err = mysql.ListNotificationsAfter(userID, lastID, limit)
+	}
+	if err != nil {
+		return nil, notifyService.nextInterval(ctx, userID, false), err
+	}
+
+	if len(events) > 0 {
+		notifyService.recordPull(ctx, userID, events[len(events)-1].ID)
+	}
+
+	delay := notifyService.nextInterval(ctx, userID, len(events) > 0)
+	return events, delay, nil
+}
+
+func (s *NotificationService) recordPull(ctx context.Context, userID, lastID int64) {
+	key := fmt.Sprintf(s.pullKey, userID)
+	_ = s.client.Set(ctx, key, lastID, 24*time.Hour).Err()
+}
+
+func (s *NotificationService) getLastPulledID(ctx context.Context, userID int64) int64 {
+	key := fmt.Sprintf(s.pullKey, userID)
+	val, err := s.client.Get(ctx, key).Int64()
+	if err != nil {
+		return 0
+	}
+	return val
+}
+
+func (s *NotificationService) nextInterval(ctx context.Context, userID int64, hasNew bool) time.Duration {
+	key := fmt.Sprintf(s.intervalKey, userID)
+	if hasNew {
+		_ = s.client.Set(ctx, key, int64(0), 24*time.Hour).Err()
+		return s.backoffSteps[0]
+	}
+	current, err := s.client.Get(ctx, key).Int64()
+	index := int(current)
+	if err != nil || index <= 0 {
+		index = 1
+	} else if index >= len(s.backoffSteps)-1 {
+		index = len(s.backoffSteps) - 1
+	}
+	_ = s.client.Set(ctx, key, int64(index+1), 24*time.Hour).Err()
+	return s.backoffSteps[index]
+}
+
+func jsonMarshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func jsonUnmarshalNotification(data []byte) (*models.NotificationEvent, error) {
+	var event models.NotificationEvent
+	if err := json.Unmarshal(data, &event); err != nil {
+		return nil, err
+	}
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now()
+	}
+	return &event, nil
+}

--- a/logic/post.go
+++ b/logic/post.go
@@ -1,13 +1,21 @@
 package logic
 
 import (
+	"context"
+	"database/sql"
+	"errors"
+
 	"bluebell/dao/mysql"
 	"bluebell/dao/redis"
 	"bluebell/models"
+	"bluebell/pkg/hotspot"
 	"bluebell/pkg/snowflake"
 
+	redisv8 "github.com/go-redis/redis/v8"
 	"go.uber.org/zap"
 )
+
+var hotManager = hotspot.GetManager()
 
 func CreatePost(p *models.Post) (err error) {
 	// 1. 生成post id
@@ -18,41 +26,24 @@ func CreatePost(p *models.Post) (err error) {
 		return err
 	}
 	err = redis.CreatePost(p.ID, p.CommunityID)
+	if err == nil {
+		// 帖子创建成功后立即加入布隆过滤器，减少缓存穿透
+		hotManager.Cache().AddToBloom(p.ID)
+	}
 	return
 	// 3. 返回
 }
 
 // GetPostById 根据帖子id查询帖子详情数据
 func GetPostById(pid int64) (data *models.ApiPostDetail, err error) {
-	// 查询并组合我们接口想用的数据
-	post, err := mysql.GetPostById(pid)
+	ctx := context.Background()
+	data, err = getPostDetail(ctx, pid, true)
 	if err != nil {
-		zap.L().Error("mysql.GetPostById(pid) failed",
-			zap.Int64("pid", pid),
-			zap.Error(err))
-		return
-	}
-	// 根据作者id查询作者信息
-	user, err := mysql.GetUserById(post.AuthorID)
-	if err != nil {
-		zap.L().Error("mysql.GetUserById(post.AuthorID) failed",
-			zap.Int64("author_id", post.AuthorID),
-			zap.Error(err))
-		return
-	}
-	// 根据社区id查询社区详细信息
-	community, err := mysql.GetCommunityDetailByID(post.CommunityID)
-	if err != nil {
-		zap.L().Error("mysql.GetUserById(post.AuthorID) failed",
-			zap.Int64("community_id", post.CommunityID),
-			zap.Error(err))
-		return
-	}
-	// 接口数据拼接
-	data = &models.ApiPostDetail{
-		AuthorName:      user.Username,
-		Post:            post,
-		CommunityDetail: community,
+		if !errors.Is(err, hotspot.ErrPostNotExist) {
+			zap.L().Error("getPostDetail failed",
+				zap.Int64("pid", pid),
+				zap.Error(err))
+		}
 	}
 	return
 }
@@ -65,28 +56,18 @@ func GetPostList(page, size int64) (data []*models.ApiPostDetail, err error) {
 	}
 	data = make([]*models.ApiPostDetail, 0, len(posts))
 
+	ctx := context.Background()
 	for _, post := range posts {
-		// 根据作者id查询作者信息
-		user, err := mysql.GetUserById(post.AuthorID)
-		if err != nil {
-			zap.L().Error("mysql.GetUserById(post.AuthorID) failed",
-				zap.Int64("author_id", post.AuthorID),
-				zap.Error(err))
+		postDetail, assembleErr := assemblePostDetail(post)
+		if assembleErr != nil {
+			zap.L().Error("assemblePostDetail failed",
+				zap.Int64("pid", post.ID),
+				zap.Error(assembleErr))
 			continue
 		}
-		// 根据社区id查询社区详细信息
-		community, err := mysql.GetCommunityDetailByID(post.CommunityID)
-		if err != nil {
-			zap.L().Error("mysql.GetUserById(post.AuthorID) failed",
-				zap.Int64("community_id", post.CommunityID),
-				zap.Error(err))
-			continue
-		}
-		postDetail := &models.ApiPostDetail{
-			AuthorName:      user.Username,
-			Post:            post,
-			CommunityDetail: community,
-		}
+		// 列表场景只做缓存填充，不增加浏览量
+		hotManager.ObservePost(ctx, postDetail, false)
+		_ = hotManager.Cache().SaveDetail(ctx, postDetail)
 		data = append(data, postDetail)
 	}
 	return
@@ -103,6 +84,7 @@ func GetPostList2(p *models.ParamPostList) (data []*models.ApiPostDetail, err er
 		return
 	}
 	zap.L().Debug("GetPostList2", zap.Any("ids", ids))
+	ctx := context.Background()
 	// 3. 根据id去MySQL数据库查询帖子详细信息
 	// 返回的数据还要按照我给定的id的顺序返回
 	posts, err := mysql.GetPostListByIDs(ids)
@@ -118,28 +100,16 @@ func GetPostList2(p *models.ParamPostList) (data []*models.ApiPostDetail, err er
 
 	// 将帖子的作者及分区信息查询出来填充到帖子中
 	for idx, post := range posts {
-		// 根据作者id查询作者信息
-		user, err := mysql.GetUserById(post.AuthorID)
-		if err != nil {
-			zap.L().Error("mysql.GetUserById(post.AuthorID) failed",
-				zap.Int64("author_id", post.AuthorID),
-				zap.Error(err))
+		postDetail, assembleErr := assemblePostDetail(post)
+		if assembleErr != nil {
+			zap.L().Error("assemblePostDetail failed",
+				zap.Int64("pid", post.ID),
+				zap.Error(assembleErr))
 			continue
 		}
-		// 根据社区id查询社区详细信息
-		community, err := mysql.GetCommunityDetailByID(post.CommunityID)
-		if err != nil {
-			zap.L().Error("mysql.GetUserById(post.AuthorID) failed",
-				zap.Int64("community_id", post.CommunityID),
-				zap.Error(err))
-			continue
-		}
-		postDetail := &models.ApiPostDetail{
-			AuthorName:      user.Username,
-			VoteNum:         voteData[idx],
-			Post:            post,
-			CommunityDetail: community,
-		}
+		postDetail.VoteNum = voteData[idx]
+		hotManager.ObservePost(ctx, postDetail, false)
+		_ = hotManager.Cache().SaveDetail(ctx, postDetail)
 		data = append(data, postDetail)
 	}
 	return
@@ -170,33 +140,85 @@ func GetCommunityPostList(p *models.ParamPostList) (data []*models.ApiPostDetail
 		return
 	}
 
+	ctx := context.Background()
 	// 将帖子的作者及分区信息查询出来填充到帖子中
 	for idx, post := range posts {
-		// 根据作者id查询作者信息
-		user, err := mysql.GetUserById(post.AuthorID)
-		if err != nil {
-			zap.L().Error("mysql.GetUserById(post.AuthorID) failed",
-				zap.Int64("author_id", post.AuthorID),
-				zap.Error(err))
+		postDetail, assembleErr := assemblePostDetail(post)
+		if assembleErr != nil {
+			zap.L().Error("assemblePostDetail failed",
+				zap.Int64("pid", post.ID),
+				zap.Error(assembleErr))
 			continue
 		}
-		// 根据社区id查询社区详细信息
-		community, err := mysql.GetCommunityDetailByID(post.CommunityID)
-		if err != nil {
-			zap.L().Error("mysql.GetUserById(post.AuthorID) failed",
-				zap.Int64("community_id", post.CommunityID),
-				zap.Error(err))
-			continue
-		}
-		postDetail := &models.ApiPostDetail{
-			AuthorName:      user.Username,
-			VoteNum:         voteData[idx],
-			Post:            post,
-			CommunityDetail: community,
-		}
+		postDetail.VoteNum = voteData[idx]
+		hotManager.ObservePost(ctx, postDetail, false)
+		_ = hotManager.Cache().SaveDetail(ctx, postDetail)
 		data = append(data, postDetail)
 	}
 	return
+}
+
+func getPostDetail(ctx context.Context, pid int64, withView bool) (*models.ApiPostDetail, error) {
+	// 1. 本地热点缓存
+	if detail, ok := hotManager.Cache().TryGetHot(pid); ok {
+		hotManager.ObservePost(ctx, detail, withView)
+		return detail, nil
+	}
+
+	// 2. Redis 拆分缓存
+	if detail, err := hotManager.Cache().LoadDetail(ctx, pid); err == nil {
+		hotManager.ObservePost(ctx, detail, withView)
+		return detail, nil
+	} else if !errors.Is(err, redisv8.Nil) && err != nil {
+		zap.L().Warn("LoadDetail failed", zap.Int64("pid", pid), zap.Error(err))
+	}
+
+	// 3. 布隆过滤器与空值缓存兜底
+	if !hotManager.Cache().ShouldQueryDB(ctx, pid) {
+		hotManager.Cache().CacheEmpty(ctx, pid)
+		return nil, hotspot.ErrPostNotExist
+	}
+
+	// 4. 读取数据库并写入缓存
+	detail, err := loadPostDetailFromDB(pid)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			hotManager.Cache().CacheEmpty(ctx, pid)
+		}
+		return nil, err
+	}
+	if saveErr := hotManager.Cache().SaveDetail(ctx, detail); saveErr != nil {
+		zap.L().Warn("SaveDetail failed", zap.Int64("pid", pid), zap.Error(saveErr))
+	}
+	hotManager.ObservePost(ctx, detail, withView)
+	return detail, nil
+}
+
+func loadPostDetailFromDB(pid int64) (*models.ApiPostDetail, error) {
+	post, err := mysql.GetPostById(pid)
+	if err != nil {
+		return nil, err
+	}
+	return assemblePostDetail(post)
+}
+
+func assemblePostDetail(post *models.Post) (*models.ApiPostDetail, error) {
+	if post == nil {
+		return nil, errors.New("post is nil")
+	}
+	user, err := mysql.GetUserById(post.AuthorID)
+	if err != nil {
+		return nil, err
+	}
+	community, err := mysql.GetCommunityDetailByID(post.CommunityID)
+	if err != nil {
+		return nil, err
+	}
+	return &models.ApiPostDetail{
+		AuthorName:      user.Username,
+		Post:            post,
+		CommunityDetail: community,
+	}, nil
 }
 
 // GetPostListNew  将两个查询帖子列表逻辑合二为一的函数

--- a/logic/vote.go
+++ b/logic/vote.go
@@ -1,10 +1,15 @@
 package logic
 
 import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
 	"bluebell/dao/mysql"
 	"bluebell/dao/redis"
 	"bluebell/models"
-	"strconv"
+	"bluebell/pkg/hotspot"
 
 	"go.uber.org/zap"
 )
@@ -17,19 +22,19 @@ import (
 
 /* 投票的几种情况：
 direction=1时，有两种情况：
-	1. 之前没有投过票，现在投赞成票    --> 更新分数和投票记录
-	2. 之前投反对票，现在改投赞成票    --> 更新分数和投票记录
+        1. 之前没有投过票，现在投赞成票    --> 更新分数和投票记录
+        2. 之前投反对票，现在改投赞成票    --> 更新分数和投票记录
 direction=0时，有两种情况：
-	1. 之前投过赞成票，现在要取消投票  --> 更新分数和投票记录
-	2. 之前投过反对票，现在要取消投票  --> 更新分数和投票记录
+        1. 之前投过赞成票，现在要取消投票  --> 更新分数和投票记录
+        2. 之前投过反对票，现在要取消投票  --> 更新分数和投票记录
 direction=-1时，有两种情况：
-	1. 之前没有投过票，现在投反对票    --> 更新分数和投票记录
-	2. 之前投赞成票，现在改投反对票    --> 更新分数和投票记录
+        1. 之前没有投过票，现在投反对票    --> 更新分数和投票记录
+        2. 之前投赞成票，现在改投反对票    --> 更新分数和投票记录
 
 投票的限制：
 每个贴子自发表之日起一个星期之内允许用户投票，超过一个星期就不允许再投票了。
-	1. 到期之后将redis中保存的赞成票数及反对票数存储到mysql表中
-	2. 到期之后删除那个 KeyPostVotedZSetPF
+        1. 到期之后将redis中保存的赞成票数及反对票数存储到mysql表中
+        2. 到期之后删除那个 KeyPostVotedZSetPF
 */
 
 // VoteForPost 为帖子投票的函数
@@ -38,16 +43,68 @@ func VoteForPost(userID int64, p *models.ParamVoteData) error {
 		zap.Int64("userID", userID),
 		zap.String("postID", p.PostID),
 		zap.Int8("direction", p.Direction))
-	err := redis.VoteForPost(strconv.Itoa(int(userID)), p.PostID, float64(p.Direction))
+	prev, err := redis.VoteForPost(strconv.Itoa(int(userID)), p.PostID, float64(p.Direction))
 	if err != nil {
 		return err
 	}
+	pid := pidFromString(p.PostID)
+
 	// 同步写入MySQL，做幂等性处理
-	// 幂等性处理是指，如果用户已经投票，则不重复投票
 	if p.Direction == 0 {
 		// 取消点赞，删除记录
+		handleLikeDelta(userID, pid, prev, 0)
 		return mysql.DeletePostVote(userID, p.PostID)
 	}
 	// 点赞或反对，插入或更新记录
-	return mysql.InsertPostVote(userID, p.PostID, p.Direction)
+	if err := mysql.InsertPostVote(userID, p.PostID, p.Direction); err != nil {
+		return err
+	}
+	handleLikeDelta(userID, pid, prev, float64(p.Direction))
+	return nil
+}
+
+func pidFromString(pid string) int64 {
+	value, _ := strconv.ParseInt(pid, 10, 64)
+	return value
+}
+
+func handleLikeDelta(actorID, pid int64, prev, current float64) {
+	if pid == 0 {
+		return
+	}
+	var delta int64
+	switch {
+	case current == 1 && prev < 1:
+		delta = 1
+	case current <= 0 && prev > 0:
+		delta = -1
+	}
+	if delta == 0 {
+		return
+	}
+	ctx := context.Background()
+	detail, err := getPostDetail(ctx, pid, false)
+	var created time.Time
+	if err == nil && detail != nil && detail.Post != nil {
+		created = detail.Post.CreateTime
+	}
+	if created.IsZero() {
+		created = time.Now()
+	}
+	hotspot.GetManager().HandleLikeEvent(ctx, pid, created, delta)
+
+	if delta > 0 && detail != nil && detail.Post != nil && detail.Post.AuthorID != actorID {
+		message := fmt.Sprintf("用户 %d 点赞了你的帖子《%s》", actorID, detail.Post.Title)
+		event := &models.NotificationEvent{
+			ReceiverID: detail.Post.AuthorID,
+			ActorID:    actorID,
+			PostID:     pid,
+			Type:       "like",
+			Message:    message,
+			CreatedAt:  time.Now(),
+		}
+		if err := PublishLikeNotification(ctx, event); err != nil {
+			zap.L().Error("PublishLikeNotification failed", zap.Error(err))
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"os"
+
 	"bluebell/controller"
 	"bluebell/dao/mysql"
 	"bluebell/dao/redis"
 	"bluebell/logger"
+	"bluebell/logic"
 	"bluebell/pkg/snowflake"
 	"bluebell/router"
 	"bluebell/setting"
-	"fmt"
-	"os"
 )
 
 // @title bluebell项目接口文档
@@ -47,6 +50,9 @@ func main() {
 		return
 	}
 	defer redis.Close()
+
+	// 启动通知异步消费，配合点赞、评论写入 MQ 的策略。
+	logic.StartNotificationConsumer(context.Background())
 
 	if err := snowflake.Init(setting.Conf.StartTime, setting.Conf.MachineID); err != nil {
 		fmt.Printf("init snowflake failed, err:%v\n", err)

--- a/models/params.go
+++ b/models/params.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 // 定义请求的参数结构体
 
 const (
@@ -34,4 +36,22 @@ type ParamPostList struct {
 	Page        int64  `json:"page" form:"page" example:"1"`       // 页码
 	Size        int64  `json:"size" form:"size" example:"10"`      // 每页数据量
 	Order       string `json:"order" form:"order" example:"score"` // 排序依据
+}
+
+// NotificationEvent 消息通知事件在 MQ 中的载体。
+type NotificationEvent struct {
+	ID         int64     `json:"id"`
+	ReceiverID int64     `json:"receiver_id"`
+	ActorID    int64     `json:"actor_id"`
+	PostID     int64     `json:"post_id"`
+	CommentID  int64     `json:"comment_id"`
+	Type       string    `json:"type"` // like/comment
+	Message    string    `json:"message"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// NotificationPullParam 前端拉取通知时的查询参数。
+type NotificationPullParam struct {
+	LastID int64 `json:"last_id" form:"last_id"`
+	Limit  int   `json:"limit" form:"limit"`
 }

--- a/pkg/hotspot/bloom.go
+++ b/pkg/hotspot/bloom.go
@@ -1,0 +1,60 @@
+package hotspot
+
+import (
+	"hash/fnv"
+	"math/big"
+	"sync"
+)
+
+// bloomFilter 是一个极简实现，用于防止缓存穿透。
+type bloomFilter struct {
+	m    uint
+	k    uint
+	bits *big.Int
+	mu   sync.RWMutex
+}
+
+func newBloomFilter(m, k uint) *bloomFilter {
+	if m == 0 {
+		m = 1 << 20
+	}
+	if k == 0 {
+		k = 3
+	}
+	return &bloomFilter{
+		m:    m,
+		k:    k,
+		bits: big.NewInt(0),
+	}
+}
+
+func (b *bloomFilter) Add(data []byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, loc := range b.locations(data) {
+		b.bits.SetBit(b.bits, int(loc), 1)
+	}
+}
+
+func (b *bloomFilter) Test(data []byte) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for _, loc := range b.locations(data) {
+		if b.bits.Bit(int(loc)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *bloomFilter) locations(data []byte) []uint {
+	results := make([]uint, 0, b.k)
+	h := fnv.New64a()
+	_, _ = h.Write(data)
+	base := h.Sum64()
+	for i := uint(0); i < b.k; i++ {
+		combined := base + uint64(i)*0x9e3779b97f4a7c15
+		results = append(results, uint(combined%uint64(b.m)))
+	}
+	return results
+}

--- a/pkg/hotspot/like_buffer.go
+++ b/pkg/hotspot/like_buffer.go
@@ -1,0 +1,79 @@
+package hotspot
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// likeBuffer 将热点帖子点赞的增量缓存在本地，满足阈值后再批量落库。
+type likeBuffer struct {
+	mu        sync.Mutex
+	threshold int64
+	window    time.Duration
+	entries   map[int64]*likeEntry
+}
+
+type likeEntry struct {
+	delta     int64
+	firstTime time.Time
+}
+
+func newLikeBuffer(threshold int64, window time.Duration) *likeBuffer {
+	if threshold <= 0 {
+		threshold = 50
+	}
+	if window <= 0 {
+		window = 10 * time.Second
+	}
+	return &likeBuffer{
+		threshold: threshold,
+		window:    window,
+		entries:   make(map[int64]*likeEntry),
+	}
+}
+
+// Add 会累积帖子 postID 的点赞增量，并在达到阈值或时间窗时返回需要落库的值。
+func (b *likeBuffer) Add(postID int64, delta int64) (flush bool, flushValue int64) {
+	if delta == 0 {
+		return false, 0
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	entry, ok := b.entries[postID]
+	if !ok {
+		entry = &likeEntry{firstTime: time.Now()}
+		b.entries[postID] = entry
+	}
+	entry.delta += delta
+	if entry.delta == 0 {
+		entry.firstTime = time.Now()
+		return false, 0
+	}
+
+	if math.Abs(float64(entry.delta)) >= float64(b.threshold) || time.Since(entry.firstTime) >= b.window {
+		flushValue = entry.delta
+		entry.delta = 0
+		entry.firstTime = time.Now()
+		return true, flushValue
+	}
+	return false, 0
+}
+
+// ForceFlush 将缓存中所有未落库的增量一次性返回，通常用于定时器或服务关闭时调用。
+func (b *likeBuffer) ForceFlush() map[int64]int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	result := make(map[int64]int64, len(b.entries))
+	for id, entry := range b.entries {
+		if entry.delta != 0 {
+			result[id] = entry.delta
+			entry.delta = 0
+			entry.firstTime = time.Now()
+		}
+	}
+	return result
+}

--- a/pkg/hotspot/local_cache.go
+++ b/pkg/hotspot/local_cache.go
@@ -1,0 +1,86 @@
+package hotspot
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// localCache 是一个简单的 LRU + TTL 组合缓存，用于热点帖子在本地内存中的快速读取。
+//
+// 设计目标：
+//  1. 控制缓存容量，避免热点帖过多时占用过多内存；
+//  2. 支持 TTL，在热点衰减后能够自动淘汰；
+//  3. 尽量保持实现简单，减少对现有结构的侵入。
+type localCache struct {
+	mu       sync.RWMutex
+	ttl      time.Duration
+	capacity int
+	items    map[int64]*list.Element
+	list     *list.List
+}
+
+type cacheEntry struct {
+	key    int64
+	value  interface{}
+	expire time.Time
+}
+
+func newLocalCache(capacity int, ttl time.Duration) *localCache {
+	if capacity <= 0 {
+		capacity = 128
+	}
+	return &localCache{
+		ttl:      ttl,
+		capacity: capacity,
+		items:    make(map[int64]*list.Element, capacity),
+		list:     list.New(),
+	}
+}
+
+func (c *localCache) Get(key int64) (interface{}, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if ele, ok := c.items[key]; ok {
+		entry := ele.Value.(*cacheEntry)
+		if entry.expire.After(time.Now()) {
+			c.list.MoveToFront(ele)
+			return entry.value, true
+		}
+		c.removeElement(ele)
+	}
+	return nil, false
+}
+
+func (c *localCache) Set(key int64, value interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if ele, ok := c.items[key]; ok {
+		c.list.MoveToFront(ele)
+		ele.Value.(*cacheEntry).value = value
+		ele.Value.(*cacheEntry).expire = time.Now().Add(c.ttl)
+		return
+	}
+
+	ele := c.list.PushFront(&cacheEntry{
+		key:    key,
+		value:  value,
+		expire: time.Now().Add(c.ttl),
+	})
+	c.items[key] = ele
+
+	if c.list.Len() > c.capacity {
+		c.removeElement(c.list.Back())
+	}
+}
+
+func (c *localCache) removeElement(ele *list.Element) {
+	if ele == nil {
+		return
+	}
+	c.list.Remove(ele)
+	entry := ele.Value.(*cacheEntry)
+	delete(c.items, entry.key)
+}

--- a/pkg/hotspot/manager.go
+++ b/pkg/hotspot/manager.go
@@ -1,0 +1,200 @@
+package hotspot
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"bluebell/dao/mysql"
+	redispkg "bluebell/dao/redis"
+	"bluebell/models"
+
+	redis "github.com/go-redis/redis/v8"
+	"go.uber.org/zap"
+)
+
+// Manager 将热点识别、点赞缓冲和排行榜维护组合在一起，对外提供统一接口。
+type Manager struct {
+	cache      *PostCache
+	likeBuffer *likeBuffer
+	ranking    *rankingManager
+	client     *redis.Client
+
+	decay       float64
+	hotScore    float64
+	flushTicker *time.Ticker
+	once        sync.Once
+	mu          sync.RWMutex
+	hotPosts    map[int64]struct{}
+}
+
+// NewManager 构造热点管理器。
+func NewManager() *Manager {
+	client := redispkg.GetClient()
+	m := &Manager{
+		cache:      NewPostCache(512),
+		likeBuffer: newLikeBuffer(50, 10*time.Second),
+		ranking:    newRankingManager(200),
+		client:     client,
+		decay:      0.1,
+		hotScore:   120,
+		hotPosts:   make(map[int64]struct{}),
+	}
+	m.startFlushLoop()
+	return m
+}
+
+func (m *Manager) startFlushLoop() {
+	m.once.Do(func() {
+		m.flushTicker = time.NewTicker(10 * time.Minute)
+		go func() {
+			for range m.flushTicker.C {
+				m.FlushRanking(context.Background())
+				m.FlushLikeBuffer(context.Background())
+			}
+		}()
+	})
+}
+
+// Cache 返回帖子缓存组件，用于帖子查询逻辑。
+func (m *Manager) Cache() *PostCache {
+	return m.cache
+}
+
+// ObservePost 在帖子被访问后调用，记录浏览量并尝试识别热点。
+func (m *Manager) ObservePost(ctx context.Context, detail *models.ApiPostDetail, withView bool) {
+	if detail == nil || detail.Post == nil {
+		return
+	}
+	pid := detail.Post.ID
+	if withView {
+		m.addMetric(ctx, pid, detail.Post.CreateTime, "views", 1)
+	}
+	score := m.calculateAndUpdate(ctx, pid, detail.Post.CreateTime)
+	if score >= m.hotScore {
+		m.markHot(detail, score)
+	}
+}
+
+func (m *Manager) markHot(detail *models.ApiPostDetail, score float64) {
+	pid := detail.Post.ID
+	m.mu.Lock()
+	_, alreadyHot := m.hotPosts[pid]
+	m.hotPosts[pid] = struct{}{}
+	m.mu.Unlock()
+
+	if !alreadyHot {
+		// 将帖子写入本地热点缓存，提高命中率
+		m.cache.PromoteHot(pid, detail, 5*time.Minute)
+	}
+	m.ranking.Update(pid, score)
+}
+
+// FlushRanking 将本地排名快照批量写入 Redis ZSET。
+func (m *Manager) FlushRanking(ctx context.Context) {
+	snapshot := m.ranking.Snapshot()
+	if len(snapshot) == 0 {
+		return
+	}
+	members := make([]*redis.Z, 0, len(snapshot))
+	for _, item := range snapshot {
+		members = append(members, &redis.Z{Score: item.score, Member: item.key})
+	}
+	_ = m.client.ZAdd(ctx, "bluebell:hot:ranking", members...).Err()
+}
+
+// FlushLikeBuffer 将热点帖子的点赞增量批量写入 Redis 和数据库。
+func (m *Manager) FlushLikeBuffer(ctx context.Context) {
+	entries := m.likeBuffer.ForceFlush()
+	for pid, delta := range entries {
+		m.persistLikeDelta(ctx, pid, delta)
+	}
+}
+
+// HandleLikeEvent 处理点赞增量，热点帖子触发缓冲策略。
+func (m *Manager) HandleLikeEvent(ctx context.Context, pid int64, createdAt time.Time, delta int64) {
+	score := m.addMetric(ctx, pid, createdAt, "likes", delta)
+	if score >= m.hotScore {
+		m.mu.Lock()
+		m.hotPosts[pid] = struct{}{}
+		m.mu.Unlock()
+	}
+	if m.isHot(pid) {
+		if flush, value := m.likeBuffer.Add(pid, delta); flush {
+			m.persistLikeDelta(ctx, pid, value)
+		}
+	} else {
+		m.persistLikeDelta(ctx, pid, delta)
+	}
+}
+
+// HandleCommentEvent 评论同样参与热度计算。
+func (m *Manager) HandleCommentEvent(ctx context.Context, pid int64, createdAt time.Time, delta int64) {
+	m.addMetric(ctx, pid, createdAt, "comments", delta)
+}
+
+func (m *Manager) isHot(pid int64) bool {
+	m.mu.RLock()
+	_, ok := m.hotPosts[pid]
+	m.mu.RUnlock()
+	return ok
+}
+
+func (m *Manager) addMetric(ctx context.Context, pid int64, createdAt time.Time, field string, delta int64) float64 {
+	if pid == 0 {
+		return 0
+	}
+	key := "bluebell:hot:metric:" + strconv.FormatInt(pid, 10)
+	_ = m.client.HIncrBy(ctx, key, field, delta).Err()
+	_ = m.client.Expire(ctx, key, 24*time.Hour).Err()
+	return m.calculateAndUpdate(ctx, pid, createdAt)
+}
+
+func (m *Manager) calculateAndUpdate(ctx context.Context, pid int64, createdAt time.Time) float64 {
+	key := "bluebell:hot:metric:" + strconv.FormatInt(pid, 10)
+	data, err := m.client.HGetAll(ctx, key).Result()
+	if err != nil {
+		return 0
+	}
+	views := parseInt64(data["views"])
+	likes := parseInt64(data["likes"])
+	comments := parseInt64(data["comments"])
+	score := HeatScore(views, likes, comments, createdAt, m.decay)
+	m.ranking.Update(pid, score)
+	return score
+}
+
+func parseInt64(v string) int64 {
+	if v == "" {
+		return 0
+	}
+	value, _ := strconv.ParseInt(v, 10, 64)
+	return value
+}
+
+func (m *Manager) persistLikeDelta(ctx context.Context, pid int64, delta int64) {
+	if delta == 0 {
+		return
+	}
+	field := "bluebell:hot:likes:" + strconv.FormatInt(pid, 10)
+	_ = m.client.IncrBy(ctx, field, delta).Err()
+	_ = m.client.Expire(ctx, field, 24*time.Hour).Err()
+	if err := mysql.UpsertPostLikeStat(pid, delta); err != nil {
+		zap.L().Error("UpsertPostLikeStat failed", zap.Int64("pid", pid), zap.Error(err))
+	}
+}
+
+// GlobalManager 为外部调用提供一个懒加载的单例，避免在不同逻辑中重复创建对象。
+var (
+	globalManager     *Manager
+	globalManagerOnce sync.Once
+)
+
+// GetManager 返回全局热点管理器实例。
+func GetManager() *Manager {
+	globalManagerOnce.Do(func() {
+		globalManager = NewManager()
+	})
+	return globalManager
+}

--- a/pkg/hotspot/post_cache.go
+++ b/pkg/hotspot/post_cache.go
@@ -1,0 +1,222 @@
+package hotspot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	redispkg "bluebell/dao/redis"
+	"bluebell/models"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+// ErrPostNotExist 表示布隆过滤器判定帖子不存在，避免对数据库造成穿透。
+var ErrPostNotExist = errors.New("post not exist")
+
+// PostCache 封装帖子详情的多级缓存逻辑。
+type PostCache struct {
+	client       *redis.Client
+	bloom        *bloomFilter
+	hotCache     *localCache
+	emptyTTL     time.Duration
+	postTTL      time.Duration
+	userTTL      time.Duration
+	communityTTL time.Duration
+}
+
+// NewPostCache 初始化帖子缓存组件。
+func NewPostCache(capacity int) *PostCache {
+	client := redispkg.GetClient()
+	return &PostCache{
+		client:       client,
+		bloom:        newBloomFilter(1<<21, 3),
+		hotCache:     newLocalCache(capacity, 3*time.Minute),
+		emptyTTL:     3 * time.Minute,
+		postTTL:      10 * time.Minute,
+		userTTL:      30 * time.Minute,
+		communityTTL: 30 * time.Minute,
+	}
+}
+
+// AddToBloom 将新帖子的 ID 填充到布隆过滤器，避免缓存穿透。
+func (c *PostCache) AddToBloom(ids ...int64) {
+	for _, id := range ids {
+		c.bloom.Add([]byte(strconv.FormatInt(id, 10)))
+	}
+}
+
+func (c *PostCache) hotKey(pid int64) string {
+	return fmt.Sprintf("bluebell:cache:post:%d", pid)
+}
+
+func (c *PostCache) postKey(pid int64) string {
+	return fmt.Sprintf("bluebell:cache:post:%d:base", pid)
+}
+
+func (c *PostCache) userKey(uid int64) string {
+	return fmt.Sprintf("bluebell:cache:user:%d", uid)
+}
+
+func (c *PostCache) communityKey(cid int64) string {
+	return fmt.Sprintf("bluebell:cache:community:%d", cid)
+}
+
+func (c *PostCache) voteKey(pid int64) string {
+	return fmt.Sprintf("bluebell:cache:post:%d:votes", pid)
+}
+
+func (c *PostCache) emptyKey(pid int64) string {
+	return fmt.Sprintf("bluebell:cache:post:%d:empty", pid)
+}
+
+// TryGetHot 尝试从本地热点缓存中获取帖子详情。
+func (c *PostCache) TryGetHot(pid int64) (*models.ApiPostDetail, bool) {
+	if v, ok := c.hotCache.Get(pid); ok {
+		if detail, ok := v.(*models.ApiPostDetail); ok {
+			return detail, true
+		}
+	}
+	return nil, false
+}
+
+// PromoteHot 将帖子详情提升为热点，写入本地缓存。
+func (c *PostCache) PromoteHot(pid int64, detail *models.ApiPostDetail, ttl time.Duration) {
+	if ttl <= 0 {
+		ttl = 3 * time.Minute
+	}
+	if c.hotCache == nil {
+		c.hotCache = newLocalCache(256, ttl)
+	}
+	// 调整热点缓存的过期时间，使其与最新的热点策略保持一致。
+	c.hotCache.ttl = ttl
+	c.hotCache.Set(pid, detail)
+}
+
+// SaveDetail 将帖子详情拆分写入 Redis，便于细粒度复用。
+func (c *PostCache) SaveDetail(ctx context.Context, detail *models.ApiPostDetail) error {
+	postBytes, err := json.Marshal(detail.Post)
+	if err != nil {
+		return err
+	}
+	userBytes, err := json.Marshal(map[string]interface{}{
+		"username":  detail.AuthorName,
+		"author_id": detail.Post.AuthorID,
+	})
+	if err != nil {
+		return err
+	}
+	communityBytes, err := json.Marshal(detail.CommunityDetail)
+	if err != nil {
+		return err
+	}
+
+	pipeline := c.client.TxPipeline()
+	pipeline.Set(ctx, c.postKey(detail.Post.ID), postBytes, c.postTTL)
+	pipeline.Set(ctx, c.userKey(detail.Post.AuthorID), userBytes, c.userTTL)
+	pipeline.Set(ctx, c.communityKey(detail.Post.CommunityID), communityBytes, c.communityTTL)
+	pipeline.Set(ctx, c.voteKey(detail.Post.ID), strconv.FormatInt(detail.VoteNum, 10), c.postTTL)
+	_, err = pipeline.Exec(ctx)
+	if err == nil {
+		c.AddToBloom(detail.Post.ID)
+	}
+	return err
+}
+
+// CacheEmpty 在 Redis 中缓存空值，缓解穿透。
+func (c *PostCache) CacheEmpty(ctx context.Context, pid int64) {
+	_ = c.client.Set(ctx, c.emptyKey(pid), "1", c.emptyTTL).Err()
+}
+
+// existEmpty 判断是否缓存了空值。
+func (c *PostCache) existEmpty(ctx context.Context, pid int64) bool {
+	_, err := c.client.Get(ctx, c.emptyKey(pid)).Result()
+	return err == nil
+}
+
+// LoadDetail 尝试从 Redis 还原帖子详情。
+func (c *PostCache) LoadDetail(ctx context.Context, pid int64) (*models.ApiPostDetail, error) {
+	pipeline := c.client.TxPipeline()
+	postCmd := pipeline.Get(ctx, c.postKey(pid))
+	voteCmd := pipeline.Get(ctx, c.voteKey(pid))
+	_, err := pipeline.Exec(ctx)
+	if err != nil && err != redis.Nil {
+		return nil, err
+	}
+
+	postBytes, err := postCmd.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	var post models.Post
+	if err := json.Unmarshal(postBytes, &post); err != nil {
+		return nil, err
+	}
+
+	detail := &models.ApiPostDetail{Post: &post}
+
+	voteBytes, err := voteCmd.Bytes()
+	if err == nil {
+		if v, parseErr := strconv.ParseInt(string(voteBytes), 10, 64); parseErr == nil {
+			detail.VoteNum = v
+		}
+	}
+
+	if err := c.attachAuthor(ctx, detail); err != nil {
+		return nil, err
+	}
+	if err := c.attachCommunity(ctx, detail); err != nil {
+		return nil, err
+	}
+	return detail, nil
+}
+
+func (c *PostCache) attachAuthor(ctx context.Context, detail *models.ApiPostDetail) error {
+	data, err := c.client.Get(ctx, c.userKey(detail.Post.AuthorID)).Bytes()
+	if err != nil {
+		return err
+	}
+	tmp := map[string]interface{}{}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if name, ok := tmp["username"].(string); ok {
+		detail.AuthorName = name
+	}
+	return nil
+}
+
+func (c *PostCache) attachCommunity(ctx context.Context, detail *models.ApiPostDetail) error {
+	data, err := c.client.Get(ctx, c.communityKey(detail.Post.CommunityID)).Bytes()
+	if err != nil {
+		return err
+	}
+	var community models.CommunityDetail
+	if err := json.Unmarshal(data, &community); err != nil {
+		return err
+	}
+	detail.CommunityDetail = &community
+	return nil
+}
+
+// ShouldQueryDB 根据布隆过滤器和空值缓存判断是否需要访问数据库。
+func (c *PostCache) ShouldQueryDB(ctx context.Context, pid int64) bool {
+	if c.existEmpty(ctx, pid) {
+		return false
+	}
+	if !c.bloom.Test([]byte(strconv.FormatInt(pid, 10))) {
+		return false
+	}
+	return true
+}
+
+// HeatScore 根据浏览量、点赞数、评论数和时间衰减计算热度值。
+func HeatScore(views, likes, comments int64, createdAt time.Time, decay float64) float64 {
+	days := time.Since(createdAt).Hours() / 24
+	weight := 0.5*float64(likes) + 0.3*float64(views) + 0.2*float64(comments)
+	return weight * math.Exp(-decay*days)
+}

--- a/pkg/hotspot/ranking.go
+++ b/pkg/hotspot/ranking.go
@@ -1,0 +1,86 @@
+package hotspot
+
+import (
+	"container/heap"
+	"sync"
+)
+
+// rankingManager 维护热点帖子的有限优先队列，结合 map + 小顶堆实现。
+type rankingManager struct {
+	mu      sync.Mutex
+	maxSize int
+	pq      priorityQueue
+	index   map[int64]int
+}
+
+type element struct {
+	key   int64
+	score float64
+}
+
+type priorityQueue []element
+
+func (pq priorityQueue) Len() int { return len(pq) }
+
+func (pq priorityQueue) Less(i, j int) bool {
+	// 小顶堆：分数越小优先被淘汰
+	return pq[i].score < pq[j].score
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *priorityQueue) Push(x interface{}) {
+	*pq = append(*pq, x.(element))
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[:n-1]
+	return item
+}
+
+func newRankingManager(maxSize int) *rankingManager {
+	if maxSize <= 0 {
+		maxSize = 200
+	}
+	return &rankingManager{
+		maxSize: maxSize,
+		pq:      make(priorityQueue, 0, maxSize),
+		index:   make(map[int64]int, maxSize),
+	}
+}
+
+func (m *rankingManager) Update(key int64, score float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if idx, ok := m.index[key]; ok {
+		m.pq[idx].score = score
+		heap.Fix(&m.pq, idx)
+		return
+	}
+
+	heap.Push(&m.pq, element{key: key, score: score})
+	m.index[key] = len(m.pq) - 1
+	if len(m.pq) > m.maxSize {
+		removed := heap.Pop(&m.pq).(element)
+		delete(m.index, removed.key)
+		// 更新索引表（被移除元素之后的索引全部左移）
+		for i := range m.pq {
+			m.index[m.pq[i].key] = i
+		}
+	}
+}
+
+func (m *rankingManager) Snapshot() []element {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]element, len(m.pq))
+	copy(result, m.pq)
+	return result
+}


### PR DESCRIPTION
## Summary
- add hotspot manager with bloom filter, local cache, like buffer and ranking writer
- refactor post and vote logic to use cached assembly, hot metrics and notification publishing
- introduce notification persistence helpers plus async consumer startup

## Testing
- `go test ./...` *(fails: requires external MySQL/Redis services and hangs waiting for connection)*

------
https://chatgpt.com/codex/tasks/task_e_68ce572302f4832698dcb9cafd19b5d7